### PR TITLE
Compile commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ objs/
 deps/
 .vscode/
 WebServ
+compile_commands.json

--- a/code/Makefile
+++ b/code/Makefile
@@ -40,7 +40,7 @@ DEPS_FILES		:=	$(OBJS_FILES:.o=.d)
 DEPS			:=	$(addprefix $(DEPS_DIR), $(DEPS_FILES))
 
 # RULES
-all: $(NAME)
+all: compile_commands.json $(NAME)
 
 $(NAME): $(OBJS) $(MAKEFILE) $(MAKEFILE) $(CONFIG)
 	$(CC) $(FLAGS) $(INCLUDES) $(OBJS) -o $@
@@ -68,5 +68,8 @@ fclean: clean
 	rm -f $(NAME)
 
 re: fclean all
+
+compile_commands.json: $(MAKEFILE) $(CONFIG)
+	-bear --output ../compile_commands.json -- make $(NAME)
 
 .PHONY: all clean fclean re

--- a/code/Makefile
+++ b/code/Makefile
@@ -40,7 +40,7 @@ DEPS_FILES		:=	$(OBJS_FILES:.o=.d)
 DEPS			:=	$(addprefix $(DEPS_DIR), $(DEPS_FILES))
 
 # RULES
-all: compile_commands.json $(NAME)
+all: $(NAME)
 
 $(NAME): $(OBJS) $(MAKEFILE) $(MAKEFILE) $(CONFIG)
 	$(CC) $(FLAGS) $(INCLUDES) $(OBJS) -o $@
@@ -69,7 +69,7 @@ fclean: clean
 
 re: fclean all
 
-compile_commands.json: $(MAKEFILE) $(CONFIG)
+bear: $(MAKEFILE) $(CONFIG)
 	-bear --output ../compile_commands.json -- make $(NAME)
 
 .PHONY: all clean fclean re


### PR DESCRIPTION
Added a rule to create a compile_commands.json file when calling make all.
It allows lsp to works.
It uses bear to create the compile_commands.son
If bear is not installed on the machine, an error is shown but the makefile doesn't crash